### PR TITLE
Add backend with realtime messaging and client scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.env
+notes.txt
+uploads
+coverage
+client/node_modules
+server/node_modules

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CougarFinder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cougarfinder-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "sass": "^1.77.6",
+    "vite": "^5.3.1",
+    "vitest": "^1.6.0"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,26 @@
+import useContent from './hooks/useContent.js';
+import styles from './app.styles.scss';
+
+const App = () => {
+  const homeContent = useContent('home');
+
+  if (!homeContent) {
+    return <div className={styles.container}>Loading...</div>;
+  }
+
+  const handleCtaClick = () => {
+    window.location.href = '/signup';
+  };
+
+  return (
+    <main className={styles.container}>
+      <h1 className={styles.headline}>{homeContent.headline}</h1>
+      <p className={styles.subheadline}>{homeContent.subheadline}</p>
+      <button type="button" className={styles.ctaButton} onClick={handleCtaClick}>
+        {homeContent.cta}
+      </button>
+    </main>
+  );
+};
+
+export default App;

--- a/client/src/app.styles.scss
+++ b/client/src/app.styles.scss
@@ -1,0 +1,29 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+.headline {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.subheadline {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+  max-width: 540px;
+}
+
+.ctaButton {
+  background: linear-gradient(135deg, #ff6f61, #ff9472);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1rem;
+}

--- a/client/src/content.json
+++ b/client/src/content.json
@@ -1,0 +1,7 @@
+{
+  "home": {
+    "headline": "Find your perfect match",
+    "subheadline": "Connect with like-minded people nearby",
+    "cta": "Get Started"
+  }
+}

--- a/client/src/hooks/useContent.js
+++ b/client/src/hooks/useContent.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+import content from '../content.json';
+
+const useContent = (section) => {
+  return useMemo(() => content[section], [section]);
+};
+
+export default useContent;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App.jsx';
+import './styles/global.scss';
+
+const queryClient = new QueryClient();
+
+const renderApp = () => {
+  const rootElement = document.getElementById('root');
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </React.StrictMode>
+  );
+};
+
+renderApp();

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -1,0 +1,10 @@
+:root {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  color: #1f1f1f;
+  background-color: #f6f6f6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cougarfinder",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "concurrently \"npm:server\" \"npm:client\"",
+    "server": "nodemon server/index.js",
+    "client": "npm --prefix client run dev",
+    "test:server": "jest --config server/jest.config.js",
+    "test:client": "npm --prefix client run test"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dayjs": "^1.11.11",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^7.6.3",
+    "multer": "^1.4.5-lts.1",
+    "socket.io": "^4.7.5",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.1.4",
+    "nodemon": "^3.0.2",
+    "socket.io-client": "^4.7.5",
+    "supertest": "^6.3.4"
+  }
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/cougarfinder
+JWT_SECRET=change_me
+JWT_EXPIRES_IN=7d
+UPLOAD_DIR=uploads

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+const cookieParser = require('cookie-parser');
+const authRoutes = require('./routes/authRoutes');
+const userRoutes = require('./routes/userRoutes');
+const matchRoutes = require('./routes/matchRoutes');
+const messageRoutes = require('./routes/messageRoutes');
+const { errorHandler } = require('./middleware/errorHandler');
+
+const createApp = () => {
+  const app = express();
+  app.use(cors({ origin: '*', credentials: true }));
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use(cookieParser());
+
+  const uploadsDir = process.env.UPLOAD_DIR || path.join(__dirname, 'uploads');
+  app.use('/uploads', express.static(uploadsDir));
+
+  app.use('/api/auth', authRoutes);
+  app.use('/api/users', userRoutes);
+  app.use('/api/matches', matchRoutes);
+  app.use('/api/messages', messageRoutes);
+
+  app.use(errorHandler);
+
+  return app;
+};
+
+module.exports = createApp;

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,0 +1,50 @@
+const { User } = require('../models/User');
+const { hashPassword, comparePassword } = require('../utils/password');
+const { signToken } = require('../utils/token');
+
+const signup = async (req, res, next) => {
+  try {
+    const { email, password, dateOfBirth, gender, orientation, location } = req.body;
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: 'Email already registered' });
+    }
+    const passwordHash = await hashPassword(password);
+    const user = await User.create({
+      email,
+      passwordHash,
+      dateOfBirth,
+      gender,
+      orientation,
+      location,
+      profile: req.body.profile
+    });
+    const token = signToken(user);
+    res.status(201).json({ token, user });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const valid = await comparePassword(password, user.passwordHash);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = signToken(user);
+    res.json({ token, user });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  signup,
+  login
+};

--- a/server/controllers/imageController.js
+++ b/server/controllers/imageController.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const { User } = require('../models/User');
+const { buildImagePayload, uploadsRoot, deleteFile } = require('../utils/imageStorage');
+
+const listImages = async (req, res, next) => {
+  try {
+    const user = await User.findById(req.user._id);
+    res.json({ images: user.images });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const uploadImages = async (req, res, next) => {
+  try {
+    const user = await User.findById(req.user._id);
+    if (user.images.length + req.files.length > 4) {
+      req.files.forEach((file) => deleteFile(file.path));
+      return res.status(400).json({ message: 'Maximum of 4 images allowed' });
+    }
+    const newImages = req.files.map((file) => buildImagePayload(user._id, path.basename(file.path)));
+    user.images.push(...newImages);
+    user.counters.photoCount = user.images.length;
+    if (!user.hasPrimary && user.images.length > 0) {
+      user.images[0].isPrimary = true;
+      user.hasPrimary = true;
+    }
+    await user.save();
+    res.status(201).json({ images: user.images });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const setPrimaryImage = async (req, res, next) => {
+  try {
+    const { imageId } = req.params;
+    const user = await User.findById(req.user._id);
+    const image = user.images.id(imageId);
+    if (!image) {
+      return res.status(404).json({ message: 'Image not found' });
+    }
+    user.images.forEach((img) => {
+      img.isPrimary = img._id.equals(image._id);
+    });
+    user.hasPrimary = true;
+    await user.save();
+    res.json({ images: user.images });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const deleteImage = async (req, res, next) => {
+  try {
+    const { imageId } = req.params;
+    const user = await User.findById(req.user._id);
+    const image = user.images.id(imageId);
+    if (!image) {
+      return res.status(404).json({ message: 'Image not found' });
+    }
+    const absolutePath = path.join(uploadsRoot, req.user._id.toString(), image.filename);
+    deleteFile(absolutePath);
+    image.remove();
+    user.counters.photoCount = user.images.length;
+    if (!user.images.some((img) => img.isPrimary)) {
+      user.hasPrimary = false;
+    }
+    await user.save();
+    res.json({ images: user.images });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  listImages,
+  uploadImages,
+  setPrimaryImage,
+  deleteImage
+};

--- a/server/controllers/matchController.js
+++ b/server/controllers/matchController.js
@@ -1,0 +1,43 @@
+const dayjs = require('dayjs');
+const { User } = require('../models/User');
+
+const buildAgeFilter = (minAge, maxAge) => {
+  const now = dayjs();
+  const maxDob = now.subtract(minAge || 18, 'year').endOf('day').toDate();
+  const minDob = now.subtract(maxAge || 99, 'year').startOf('day').toDate();
+  return { $gte: minDob, $lte: maxDob };
+};
+
+const browseMatches = async (req, res, next) => {
+  try {
+    const { ageMin, ageMax, distance, orientations } = req.query;
+    const user = req.user;
+    const filters = {
+      _id: { $ne: user._id },
+      status: 'active'
+    };
+    if (ageMin || ageMax) {
+      filters.dateOfBirth = buildAgeFilter(Number(ageMin) || 18, Number(ageMax) || 99);
+    }
+    if (orientations) {
+      const parsed = orientations.split(',');
+      filters.orientation = { $in: parsed };
+    }
+    let query = User.find(filters).select('-passwordHash');
+    if (user.location && user.location.coordinates && typeof distance !== 'undefined') {
+      const distMeters = Number(distance) * 1000 || user.profile.preferences.distance * 1000;
+      query = query.where('location').near({
+        center: { type: 'Point', coordinates: user.location.coordinates },
+        maxDistance: distMeters
+      });
+    }
+    const results = await query.limit(50);
+    res.json({ matches: results });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  browseMatches
+};

--- a/server/controllers/messageController.js
+++ b/server/controllers/messageController.js
@@ -1,0 +1,49 @@
+const { Message } = require('../models/Message');
+const { buildConvoId } = require('../utils/conversation');
+
+const getMessages = async (req, res, next) => {
+  try {
+    const { withUserId, limit = 50 } = req.query;
+    if (!withUserId) {
+      return res.status(400).json({ message: 'withUserId is required' });
+    }
+    const convoId = buildConvoId(req.user._id, withUserId);
+    const messages = await Message.find({ convoId })
+      .sort({ createdAt: -1 })
+      .limit(Number(limit))
+      .lean();
+    res.json({ messages: messages.reverse() });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const listConversations = async (req, res, next) => {
+  try {
+    const conversations = await Message.aggregate([
+      {
+        $match: {
+          $or: [
+            { fromUserId: req.user._id },
+            { toUserId: req.user._id }
+          ]
+        }
+      },
+      { $sort: { createdAt: -1 } },
+      {
+        $group: {
+          _id: '$convoId',
+          lastMessage: { $first: '$$ROOT' }
+        }
+      }
+    ]);
+    res.json({ conversations });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  getMessages,
+  listConversations
+};

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,0 +1,44 @@
+const { User } = require('../models/User');
+const { Like } = require('../models/Like');
+
+const getMe = async (req, res, next) => {
+  try {
+    res.json({ user: req.user });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const updateProfile = async (req, res, next) => {
+  try {
+    const updates = req.body;
+    Object.assign(req.user, updates);
+    await req.user.save();
+    res.json({ user: req.user });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const sendLike = async (req, res, next) => {
+  try {
+    const { targetUserId } = req.body;
+    if (targetUserId === req.user._id.toString()) {
+      return res.status(400).json({ message: 'Cannot like yourself' });
+    }
+    const like = await Like.findOneAndUpdate(
+      { fromUserId: req.user._id, toUserId: targetUserId },
+      {},
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    res.status(201).json({ like });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  getMe,
+  updateProfile,
+  sendLike
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,37 @@
+require('dotenv').config({ path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env' });
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const createApp = require('./app');
+const { connectDb } = require('./utils/db');
+const { initSocket } = require('./socket');
+
+const ensureUploadRoot = () => {
+  const uploadDir = process.env.UPLOAD_DIR
+    ? path.resolve(process.cwd(), process.env.UPLOAD_DIR)
+    : path.join(__dirname, 'uploads');
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+};
+
+const start = async () => {
+  ensureUploadRoot();
+  await connectDb();
+  const app = createApp();
+  const server = http.createServer(app);
+  initSocket(server);
+  const port = process.env.PORT || 5000;
+  server.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server listening on port ${port}`);
+  });
+};
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = {
+  start
+};

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/server/tests'],
+  setupFilesAfterEnv: ['<rootDir>/server/tests/setup.js'],
+  testTimeout: 30000
+};

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+const { User } = require('../models/User');
+
+const authMiddleware = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization || '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.replace('Bearer ', '') : null;
+    if (!token) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.id);
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    req.user = user;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  authMiddleware
+};

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,0 +1,13 @@
+const errorHandler = (err, req, res, next) => {
+  const status = err.status || 500;
+  const message = err.message || 'Internal server error';
+  if (process.env.NODE_ENV !== 'test') {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+  res.status(status).json({ message, errors: err.errors || undefined });
+};
+
+module.exports = {
+  errorHandler
+};

--- a/server/models/Like.js
+++ b/server/models/Like.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const LikeSchema = new mongoose.Schema(
+  {
+    fromUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    toUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: false } }
+);
+
+LikeSchema.index({ fromUserId: 1, toUserId: 1 }, { unique: true });
+
+const Like = mongoose.model('Like', LikeSchema);
+
+module.exports = {
+  Like
+};

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const MessageSchema = new mongoose.Schema(
+  {
+    convoId: { type: String, required: true, index: true },
+    fromUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    toUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    body: { type: String, required: true },
+    deliveredAt: { type: Date },
+    readAt: { type: Date }
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: false } }
+);
+
+const Message = mongoose.model('Message', MessageSchema);
+
+module.exports = {
+  Message
+};

--- a/server/models/Report.js
+++ b/server/models/Report.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const ReportSchema = new mongoose.Schema(
+  {
+    reporterId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    targetUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    photoId: { type: mongoose.Schema.Types.ObjectId },
+    reason: { type: String, required: true },
+    details: { type: String },
+    status: { type: String, enum: ['open', 'reviewing', 'resolved'], default: 'open' }
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: false } }
+);
+
+const Report = mongoose.model('Report', ReportSchema);
+
+module.exports = {
+  Report
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,68 @@
+const mongoose = require('mongoose');
+
+const ImageSchema = new mongoose.Schema(
+  {
+    filename: { type: String, required: true },
+    ext: { type: String, required: true },
+    paths: {
+      public: { type: String, required: true },
+      thumb: { type: String, required: true }
+    },
+    isPrimary: { type: Boolean, default: false },
+    createdAt: { type: Date, default: Date.now }
+  },
+  { _id: true }
+);
+
+const PresenceSchema = new mongoose.Schema(
+  {
+    status: { type: String, enum: ['offline', 'online', 'away'], default: 'offline' },
+    lastSeen: { type: Date, default: Date.now }
+  },
+  { _id: false }
+);
+
+const LocationSchema = new mongoose.Schema(
+  {
+    type: { type: String, enum: ['Point'], default: 'Point' },
+    coordinates: { type: [Number], default: [0, 0] }
+  },
+  { _id: false }
+);
+
+const UserSchema = new mongoose.Schema(
+  {
+    email: { type: String, required: true, unique: true },
+    passwordHash: { type: String, required: true },
+    dateOfBirth: { type: Date, required: true },
+    gender: { type: String, enum: ['male', 'female', 'non-binary', 'other'], required: true },
+    orientation: { type: [String], default: [] },
+    location: { type: LocationSchema, default: () => ({ coordinates: [0, 0] }) },
+    profile: {
+      bio: { type: String, default: '' },
+      preferences: {
+        minAge: { type: Number, default: 18 },
+        maxAge: { type: Number, default: 99 },
+        distance: { type: Number, default: 50 },
+        genders: { type: [String], default: [] }
+      }
+    },
+    presence: { type: PresenceSchema, default: () => ({}) },
+    counters: {
+      photoCount: { type: Number, default: 0 }
+    },
+    hasPrimary: { type: Boolean, default: false },
+    status: { type: String, enum: ['active', 'banned', 'deleted'], default: 'active' },
+    images: { type: [ImageSchema], default: [] }
+  },
+  { timestamps: true }
+);
+
+UserSchema.index({ location: '2dsphere' });
+
+const User = mongoose.model('User', UserSchema);
+
+module.exports = {
+  User,
+  ImageSchema
+};

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { signup, login } = require('../controllers/authController');
+
+const router = express.Router();
+
+router.post('/signup', signup);
+router.post('/login', login);
+
+module.exports = router;

--- a/server/routes/matchRoutes.js
+++ b/server/routes/matchRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/authMiddleware');
+const { browseMatches } = require('../controllers/matchController');
+
+const router = express.Router();
+
+router.get('/', authMiddleware, browseMatches);
+
+module.exports = router;

--- a/server/routes/messageRoutes.js
+++ b/server/routes/messageRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/authMiddleware');
+const { getMessages, listConversations } = require('../controllers/messageController');
+
+const router = express.Router();
+
+router.use(authMiddleware);
+router.get('/', listConversations);
+router.get('/thread', getMessages);
+
+module.exports = router;

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/authMiddleware');
+const { getMe, updateProfile, sendLike } = require('../controllers/userController');
+const { listImages, uploadImages, setPrimaryImage, deleteImage } = require('../controllers/imageController');
+const { upload } = require('../utils/imageStorage');
+
+const router = express.Router();
+
+router.use(authMiddleware);
+
+router.get('/me', getMe);
+router.patch('/me', updateProfile);
+router.post('/like', sendLike);
+
+router.get('/me/images', listImages);
+router.post('/me/images', upload.array('images', 4), uploadImages);
+router.patch('/me/images/:imageId/primary', setPrimaryImage);
+router.delete('/me/images/:imageId', deleteImage);
+
+module.exports = router;

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,80 @@
+const { Server } = require('socket.io');
+const { verifySocketToken } = require('./utils/token');
+const { Message } = require('./models/Message');
+const { User } = require('./models/User');
+const { buildConvoId } = require('./utils/conversation');
+
+const activeUsers = new Map();
+
+const initSocket = (httpServer) => {
+  const io = new Server(httpServer, {
+    cors: { origin: '*', credentials: true }
+  });
+
+  io.use((socket, next) => {
+    const headerToken = socket.handshake.headers?.authorization || '';
+    const token = socket.handshake.auth?.token || (headerToken.startsWith('Bearer ') ? headerToken.replace('Bearer ', '') : null);
+    const payload = verifySocketToken(token);
+    if (!payload) {
+      return next(new Error('Unauthorized'));
+    }
+    socket.user = payload;
+    next();
+  });
+
+  io.on('connection', async (socket) => {
+    const userId = socket.user.id;
+    socket.join(`user:${userId}`);
+    activeUsers.set(userId, { socketId: socket.id, lastSeen: new Date() });
+    await User.findByIdAndUpdate(userId, {
+      presence: { status: 'online', lastSeen: new Date() }
+    });
+    io.emit('presence:user', { userId, status: 'online' });
+
+    socket.on('message:send', async (payload, callback) => {
+      try {
+        const { toUserId, body } = payload;
+        const convoId = buildConvoId(userId, toUserId);
+        const message = await Message.create({
+          convoId,
+          fromUserId: userId,
+          toUserId,
+          body
+        });
+        const emitPayload = { ...message.toObject(), createdAt: message.createdAt };
+        io.to(`user:${userId}`).to(`user:${toUserId}`).emit('message:new', emitPayload);
+        if (callback) {
+          callback({ status: 'ok', message: emitPayload });
+        }
+      } catch (error) {
+        if (callback) {
+          callback({ status: 'error', message: error.message });
+        }
+      }
+    });
+
+    socket.on('message:delivered', async ({ messageId, toUserId }) => {
+      await Message.findByIdAndUpdate(messageId, { deliveredAt: new Date() });
+      io.to(`user:${toUserId}`).emit('message:delivered', { messageId });
+    });
+
+    socket.on('message:read', async ({ messageId, toUserId }) => {
+      await Message.findByIdAndUpdate(messageId, { readAt: new Date() });
+      io.to(`user:${toUserId}`).emit('message:read', { messageId });
+    });
+
+    socket.on('disconnect', async () => {
+      activeUsers.delete(userId);
+      await User.findByIdAndUpdate(userId, {
+        presence: { status: 'offline', lastSeen: new Date() }
+      });
+      io.emit('presence:user', { userId, status: 'offline' });
+    });
+  });
+
+  return io;
+};
+
+module.exports = {
+  initSocket
+};

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,0 +1,34 @@
+const dayjs = require('dayjs');
+
+describe('Auth endpoints', () => {
+  it('registers a new user and returns token', async () => {
+    const payload = {
+      email: `test${Date.now()}@example.com`,
+      password: 'Passw0rd!',
+      dateOfBirth: dayjs().subtract(24, 'year').toDate(),
+      gender: 'female',
+      orientation: ['male'],
+      location: { type: 'Point', coordinates: [-73.935242, 40.73061] }
+    };
+    const res = await global.request.post('/api/auth/signup').send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeTruthy();
+    expect(res.body.user.email).toBe(payload.email);
+  });
+
+  it('logs in an existing user', async () => {
+    const email = `login${Date.now()}@example.com`;
+    const signupRes = await global.request.post('/api/auth/signup').send({
+      email,
+      password: 'Passw0rd!',
+      dateOfBirth: dayjs().subtract(26, 'year').toDate(),
+      gender: 'male',
+      orientation: ['female'],
+      location: { type: 'Point', coordinates: [-73.935242, 40.73061] }
+    });
+    expect(signupRes.status).toBe(201);
+    const loginRes = await global.request.post('/api/auth/login').send({ email, password: 'Passw0rd!' });
+    expect(loginRes.status).toBe(200);
+    expect(loginRes.body.token).toBeTruthy();
+  });
+});

--- a/server/tests/helpers.js
+++ b/server/tests/helpers.js
@@ -1,0 +1,44 @@
+const dayjs = require('dayjs');
+const { User } = require('../models/User');
+const { hashPassword } = require('../utils/password');
+const { signToken } = require('../utils/token');
+
+const buildUserPayload = (overrides = {}) => ({
+  email: `user${Math.random().toString(16).slice(2)}@example.com`,
+  password: 'Password123!',
+  dateOfBirth: dayjs().subtract(25, 'year').toDate(),
+  gender: 'female',
+  orientation: ['male'],
+  location: { type: 'Point', coordinates: [-118.2437, 34.0522] },
+  profile: {
+    bio: 'Test bio',
+    preferences: {
+      minAge: 21,
+      maxAge: 35,
+      distance: 100,
+      genders: ['male']
+    }
+  },
+  ...overrides
+});
+
+const createUserAndToken = async (overrides = {}) => {
+  const payload = buildUserPayload(overrides);
+  const passwordHash = await hashPassword(payload.password);
+  const user = await User.create({
+    email: payload.email,
+    passwordHash,
+    dateOfBirth: payload.dateOfBirth,
+    gender: payload.gender,
+    orientation: payload.orientation,
+    location: payload.location,
+    profile: payload.profile
+  });
+  const token = signToken(user);
+  return { user, token, password: payload.password };
+};
+
+module.exports = {
+  buildUserPayload,
+  createUserAndToken
+};

--- a/server/tests/images.test.js
+++ b/server/tests/images.test.js
@@ -1,0 +1,36 @@
+const { createUserAndToken } = require('./helpers');
+
+describe('Image management', () => {
+  it('uploads and lists images', async () => {
+    const { token } = await createUserAndToken();
+    const res = await global.request
+      .post('/api/users/me/images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('images', Buffer.from('image-one'), 'photo1.jpg');
+    expect(res.status).toBe(201);
+    expect(res.body.images.length).toBe(1);
+
+    const listRes = await global.request
+      .get('/api/users/me/images')
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.images.length).toBe(1);
+  });
+
+  it('prevents uploading more than four images', async () => {
+    const { token } = await createUserAndToken();
+    const firstUpload = await global.request
+      .post('/api/users/me/images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('images', Buffer.from('1'), '1.jpg')
+      .attach('images', Buffer.from('2'), '2.jpg')
+      .attach('images', Buffer.from('3'), '3.jpg')
+      .attach('images', Buffer.from('4'), '4.jpg');
+    expect(firstUpload.status).toBe(201);
+    const secondUpload = await global.request
+      .post('/api/users/me/images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('images', Buffer.from('5'), '5.jpg');
+    expect(secondUpload.status).toBe(400);
+  });
+});

--- a/server/tests/match.test.js
+++ b/server/tests/match.test.js
@@ -1,0 +1,36 @@
+const dayjs = require('dayjs');
+const { createUserAndToken } = require('./helpers');
+
+describe('Match browsing', () => {
+  it('returns matches filtered by age', async () => {
+    const { token } = await createUserAndToken({
+      gender: 'female',
+      orientation: ['male'],
+      dateOfBirth: dayjs().subtract(28, 'year').toDate(),
+      location: { type: 'Point', coordinates: [-118.2437, 34.0522] }
+    });
+    await createUserAndToken({
+      email: 'candidate1@example.com',
+      gender: 'male',
+      orientation: ['female'],
+      dateOfBirth: dayjs().subtract(30, 'year').toDate(),
+      location: { type: 'Point', coordinates: [-118.2437, 34.0522] }
+    });
+    await createUserAndToken({
+      email: 'candidate2@example.com',
+      gender: 'male',
+      orientation: ['female'],
+      dateOfBirth: dayjs().subtract(45, 'year').toDate(),
+      location: { type: 'Point', coordinates: [-74.006, 40.7128] }
+    });
+
+    const res = await global.request
+      .get('/api/matches')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ ageMin: 25, ageMax: 35, distance: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.matches.length).toBe(1);
+    expect(res.body.matches[0].email).toBe('candidate1@example.com');
+  });
+});

--- a/server/tests/setup.js
+++ b/server/tests/setup.js
@@ -1,0 +1,65 @@
+const path = require('path');
+const fs = require('fs');
+const http = require('http');
+const supertest = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+process.env.JWT_SECRET = 'test-secret';
+process.env.JWT_EXPIRES_IN = '1d';
+process.env.PORT = '0';
+process.env.UPLOAD_DIR = path.join(__dirname, '..', 'temp', 'test-uploads');
+
+const ensureDir = (dir) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+};
+
+ensureDir(process.env.UPLOAD_DIR);
+
+const createApp = require('../app');
+const { connectDb, disconnectDb } = require('../utils/db');
+const { initSocket } = require('../socket');
+
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await connectDb(mongoServer.getUri());
+  const app = createApp();
+  const server = http.createServer(app);
+  const io = initSocket(server);
+  await new Promise((resolve) => {
+    server.listen(0, resolve);
+  });
+  const address = server.address();
+  global.__APP__ = app;
+  global.__SERVER__ = server;
+  global.__IO__ = io;
+  global.__TEST_AGENT_URL__ = `http://127.0.0.1:${address.port}`;
+  global.request = supertest(app);
+});
+
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  await Promise.all(
+    Object.values(collections).map((collection) => collection.deleteMany({}))
+  );
+});
+
+afterAll(async () => {
+  await disconnectDb();
+  if (global.__SERVER__) {
+    await new Promise((resolve) => global.__SERVER__.close(resolve));
+  }
+  if (global.__IO__) {
+    global.__IO__.close();
+  }
+  if (mongoServer) {
+    await mongoServer.stop();
+  }
+  if (fs.existsSync(process.env.UPLOAD_DIR)) {
+    fs.rmSync(process.env.UPLOAD_DIR, { recursive: true, force: true });
+  }
+});

--- a/server/tests/socket.test.js
+++ b/server/tests/socket.test.js
@@ -1,0 +1,44 @@
+const { io: Client } = require('socket.io-client');
+const { createUserAndToken } = require('./helpers');
+
+const waitForConnection = (socket) => new Promise((resolve) => socket.on('connect', resolve));
+
+describe('Socket messaging', () => {
+  it('delivers realtime messages', async () => {
+    const sender = await createUserAndToken({ email: 'sender@example.com' });
+    const receiver = await createUserAndToken({ email: 'receiver@example.com' });
+
+    const senderSocket = new Client(global.__TEST_AGENT_URL__, {
+      auth: { token: sender.token },
+      transports: ['websocket']
+    });
+    const receiverSocket = new Client(global.__TEST_AGENT_URL__, {
+      auth: { token: receiver.token },
+      transports: ['websocket']
+    });
+
+    await Promise.all([waitForConnection(senderSocket), waitForConnection(receiverSocket)]);
+
+    const messagePromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Message not received in time'));
+      }, 5000);
+      receiverSocket.on('message:new', (payload) => {
+        clearTimeout(timeout);
+        resolve(payload);
+      });
+    });
+
+    senderSocket.emit('message:send', {
+      toUserId: receiver.user._id.toString(),
+      body: 'hello world'
+    });
+
+    const message = await messagePromise;
+    expect(message.body).toBe('hello world');
+    expect(message.fromUserId.toString()).toBe(sender.user._id.toString());
+
+    senderSocket.disconnect();
+    receiverSocket.disconnect();
+  });
+});

--- a/server/utils/conversation.js
+++ b/server/utils/conversation.js
@@ -1,0 +1,8 @@
+const buildConvoId = (userIdA, userIdB) => {
+  const sorted = [userIdA.toString(), userIdB.toString()].sort();
+  return `${sorted[0]}:${sorted[1]}`;
+};
+
+module.exports = {
+  buildConvoId
+};

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+
+const connectDb = async (mongoUri) => {
+  const uri = mongoUri || process.env.MONGO_URI;
+  if (!uri) {
+    throw new Error('MONGO_URI is not defined');
+  }
+  if (mongoose.connection.readyState === 1) {
+    return mongoose.connection;
+  }
+  mongoose.set('strictQuery', true);
+  await mongoose.connect(uri, {
+    autoIndex: true
+  });
+  return mongoose.connection;
+};
+
+const disconnectDb = async () => {
+  if (mongoose.connection.readyState !== 0) {
+    await mongoose.disconnect();
+  }
+};
+
+module.exports = {
+  connectDb,
+  disconnectDb
+};

--- a/server/utils/imageStorage.js
+++ b/server/utils/imageStorage.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+const { v4: uuidv4 } = require('uuid');
+
+const ensureDir = (dirPath) => {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+};
+
+const uploadsRoot = process.env.UPLOAD_DIR
+  ? path.resolve(process.cwd(), process.env.UPLOAD_DIR)
+  : path.join(__dirname, '..', 'uploads');
+ensureDir(uploadsRoot);
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    const userDir = path.join(uploadsRoot, req.user._id.toString());
+    ensureDir(userDir);
+    cb(null, userDir);
+  },
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname) || '.jpg';
+    cb(null, `${uuidv4()}${ext}`);
+  }
+});
+
+const upload = multer({
+  storage,
+  limits: { files: 4, fileSize: 5 * 1024 * 1024 }
+});
+
+const buildImagePayload = (userId, filename) => {
+  const ext = path.extname(filename).replace('.', '');
+  const publicPath = path.posix.join('uploads', userId.toString(), filename);
+  const thumbPath = publicPath;
+  return {
+    filename,
+    ext,
+    paths: { public: publicPath, thumb: thumbPath },
+    isPrimary: false,
+    createdAt: new Date()
+  };
+};
+
+const deleteFile = (filePath) => {
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+};
+
+module.exports = {
+  upload,
+  uploadsRoot,
+  buildImagePayload,
+  deleteFile
+};

--- a/server/utils/password.js
+++ b/server/utils/password.js
@@ -1,0 +1,13 @@
+const bcrypt = require('bcryptjs');
+
+const hashPassword = async (password) => {
+  const salt = await bcrypt.genSalt(10);
+  return bcrypt.hash(password, salt);
+};
+
+const comparePassword = async (password, hash) => bcrypt.compare(password, hash);
+
+module.exports = {
+  hashPassword,
+  comparePassword
+};

--- a/server/utils/token.js
+++ b/server/utils/token.js
@@ -1,0 +1,21 @@
+const jwt = require('jsonwebtoken');
+
+const signToken = (user) => {
+  const payload = { id: user._id.toString(), email: user.email };
+  const secret = process.env.JWT_SECRET;
+  const expiresIn = process.env.JWT_EXPIRES_IN || '7d';
+  return jwt.sign(payload, secret, { expiresIn });
+};
+
+const verifySocketToken = (token) => {
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET);
+  } catch (error) {
+    return null;
+  }
+};
+
+module.exports = {
+  signToken,
+  verifySocketToken
+};


### PR DESCRIPTION
## Summary
- implement Express-based backend with JWT auth, user profiles, image management, matching filters, and Socket.IO messaging
- define Mongoose models for users, messages, likes, and reports with supporting controllers, routes, and utilities
- add Jest and Supertest integration tests plus a Vite React client scaffold for future development

## Testing
- `npm run test:server` *(fails: jest not installed in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e4556d948330b7e85e9965bbc3ce