### PR TITLE
fix: ensure likes persist sender references

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -23,15 +23,41 @@ const updateProfile = async (req, res, next) => {
 const sendLike = async (req, res, next) => {
   try {
     const { targetUserId } = req.body;
+
+    if (!targetUserId) {
+      return res.status(400).json({ message: 'targetUserId is required' });
+    }
+
     if (targetUserId === req.user._id.toString()) {
       return res.status(400).json({ message: 'Cannot like yourself' });
     }
-    const like = await Like.findOneAndUpdate(
-      { fromUserId: req.user._id, toUserId: targetUserId },
-      {},
-      { upsert: true, new: true, setDefaultsOnInsert: true }
-    );
-    res.status(201).json({ like });
+
+    const filter = { fromUserId: req.user._id, toUserId: targetUserId };
+    const update = {
+      $setOnInsert: {
+        fromUserId: req.user._id,
+        toUserId: targetUserId
+      }
+    };
+
+    const result = await Like.findOneAndUpdate(filter, update, {
+      upsert: true,
+      new: true,
+      setDefaultsOnInsert: true,
+      rawResult: true
+    });
+
+    const like = result.value;
+    const wasCreated = !(result.lastErrorObject && result.lastErrorObject.updatedExisting);
+
+    const likeResponse = {
+      ...like,
+      _id: like._id.toString(),
+      fromUserId: like.fromUserId.toString(),
+      toUserId: like.toUserId.toString()
+    };
+
+    res.status(wasCreated ? 201 : 200).json({ like: likeResponse });
   } catch (error) {
     next(error);
   }

--- a/server/tests/like.test.js
+++ b/server/tests/like.test.js
@@ -1,0 +1,30 @@
+const { Like } = require('../models/Like');
+const { createUserAndToken } = require('./helpers');
+
+describe('User likes', () => {
+  it('creates a like with correct user references and avoids duplicates', async () => {
+    const { user: liker, token } = await createUserAndToken({ email: 'liker@example.com' });
+    const { user: target } = await createUserAndToken({ email: 'target@example.com' });
+
+    const payload = { targetUserId: target._id.toString() };
+
+    const firstResponse = await global.request
+      .post('/api/users/like')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+
+    expect(firstResponse.status).toBe(201);
+    expect(firstResponse.body.like.fromUserId).toBe(liker._id.toString());
+    expect(firstResponse.body.like.toUserId).toBe(target._id.toString());
+
+    const secondResponse = await global.request
+      .post('/api/users/like')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+
+    expect(secondResponse.status).toBe(200);
+
+    const likes = await Like.find({ fromUserId: liker._id, toUserId: target._id });
+    expect(likes).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- require a target user id for like creation and guard against self likes
- upsert likes while persisting sender and target references and return consistent responses
- add a regression test that ensures duplicate likes are not created

## Testing
- npm run test:server *(fails: jest not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fd97a4fc833094603b22c21ea762