### PR TITLE
Docs refresh: README + AGENTS (auto-derived from codebase)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,107 @@
-# CougarFinder — AGENTS
+# CougarFinder — Operational Playbook
 
-**Codename:** `CougarFinder`  
-**Owner:** DevKofi (Kofi)  
-**Stack:** MERN (MongoDB, Express (CommonJS), React (Vite), Node), SCSS Modules, React Query + custom hooks, Redux Toolkit (as needed), Jest + Supertest (server), Vitest (client)
+## Global Rules
+- JavaScript only across client and server; no TypeScript or alternative transpilers.
+- Prefer arrow functions everywhere (controllers, services, React components, hooks, utilities).
+- Backend uses Express + Mongoose in a strict MVC layout under `server/` with CommonJS (`require` / `module.exports`).
+- Frontend uses Vite + React with SCSS Modules (one `ComponentName.styles.scss` per component) and default exports.
+- React Query manages server state; wrap data access in custom hooks.
+- Keep environment-specific values in `.env` files (no hard-coded secrets). Respect `CORS_ORIGIN` wildcard in development and explicit origins in production.
+- Authentication uses JWT signed with `JWT_SECRET`. Tokens travel via `Authorization: Bearer` header for HTTP and Socket.IO.
+- Tests live on their side: Jest + Supertest under `server/tests`, Vitest under `client/src/__tests__`.
+- Follow the README for scripts, endpoints, env vars, and deployment expectations. Update docs when those change.
 
-## 1) Repo Ground Rules
-- JavaScript only (no TypeScript)
-- SCSS Modules (`ComponentName.styles.scss`) imported by the component
-- Components: Arrow functions + default export
-- Backend: Strict MVC in `/server` (no `src/`). CommonJS
-- State: React Query for server state + custom hooks
-- Env: Use `.env`; never commit secrets
+## Agents
+### Repo Guard
+- Enforces stack conventions (JS only, arrow functions, CommonJS server, SCSS Modules, React Query usage).
+- Blocks merges if linting conventions, folder structure, or security requirements (JWT, env vars, wildcard CORS in dev) are violated.
 
-```
-root/
-  client/
-    src/
-      components/
-      hooks/
-      pages/
-      styles/
-      constants/
-  server/
-    controllers/
-    models/
-    routes/
-    utils/
-    tests/
-  package.json
-  README.md
-  AGENTS.md
-  .gitignore
-```
+### API Generator (`:create:crud:[resource]`)
+- Builds model-aware CRUD endpoints under `server/routes`, `server/controllers`, optional `server/services`.
+- Must wire routes -> controllers -> models, add tests, and document endpoints in README.
 
-## 2) Git Workflow
-- Branches: `main` (deployable), `dev` (integration), features `feat/<scope>`, fixes `fix/<scope>`
-- Conventional Commits: feat, fix, refactor, chore, docs, test, perf, ci, style
-- PR checklist:
-  - [ ] Follows rules above
-  - [ ] Tests added/updated (server: Jest/Supertest; client: Vitest)
-  - [ ] README updated if setup changed
-  - [ ] No secrets in diff
-  - [ ] Lint/format passes
+### Model Wizard (`:create:model:[name]`)
+- Generates Mongoose models aligned with existing schemas and relationships.
+- Updates related controllers/services and seeds tests/data when necessary.
 
-## 3) Testing & Scripts
-- Server tests: Jest + Supertest (only under `/server`)
-- Client tests: Vitest (only under `/client`)
-- Root scripts:
-  - `npm run dev` — run server + client together (concurrently)
-  - `npm test` — server-only (Jest)
-  - `npm run test:client` — client-only (Vitest)
-  - `npm start` — start server (prod)
+### UI Builder (`:create:component:[Name]`)
+- Creates React components plus matching `Name.styles.scss` modules.
+- Hooks components into routing or parent views and ensures responsive styles.
 
-## 4) Environment
-**server/.env**
-```
-PORT=5000
-MONGO_URI=your-mongodb-uri
-JWT_SECRET=change_me
-CORS_ORIGIN=*
-```
+### Test Author
+- Adds or updates Jest + Supertest suites for API work and Vitest suites for client work.
+- Keeps fixtures isolated and leverages the in-memory MongoDB test harness.
 
-**client/src/constants/baseURL.js**
+### Docs Scribe
+- Maintains `README.md` and related docs when APIs, env vars, scripts, or workflows change.
+- Ensures tables, endpoint lists, and deployment notes mirror the current code.
+
+### Release Butler
+- Runs all tests, updates changelog/release notes, tags the release, and outlines deploy commands.
+- Verifies that README deployment instructions still match the commands executed.
+
+## Code Templates
+### Express Controller (CommonJS + Arrow Function)
 ```js
-export const BASE_URL = import.meta.env.VITE_API_BASE || 'http://localhost:5000';
+const someService = require('../services/someService');
+
+const listItems = async (req, res, next) => {
+  try {
+    const items = await someService.list();
+    res.json({ items });
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  listItems
+};
 ```
 
-**client/.env**
-```
-VITE_API_BASE=http://localhost:5000
-```
-
-## 5) Patterns
-- React
+### React Component + SCSS Module
 ```jsx
-import styles from './Component.styles.scss';
-const Component = ({ title }) => <h1 className={styles.title}>{title}</h1>;
-export default Component;
+import styles from './ComponentName.styles.scss';
+
+const ComponentName = ({ title }) => {
+  return <h1 className={styles.title}>{title}</h1>;
+};
+
+export default ComponentName;
 ```
 
-- Routes → Controllers: routes validate + call controller; controllers hold logic
+### React Query Hook
+```js
+import { useQuery } from '@tanstack/react-query';
+import { BASE_URL } from '../constants/baseURL';
 
-## 6) Health Check
-`GET /api/health -> 200 { ok: true, service: 'CougarFinder' }`
+const fetchItems = async () => {
+  const response = await fetch(`${BASE_URL}/api/items`, {
+    credentials: 'include'
+  });
 
-## 7) Security (prod)
-- Basic rate limiting on auth
-- No PII in logs; scrub tokens
-- Prefer JWT in Authorization header; cookies httpOnly if used
+  if (!response.ok) {
+    throw new Error('Failed to fetch items');
+  }
+
+  return response.json();
+};
+
+const useItems = (options = {}) => {
+  return useQuery({
+    queryKey: ['items'],
+    queryFn: fetchItems,
+    ...options
+  });
+};
+
+export default useItems;
+```
+
+## PR Checklist
+- [ ] Arrow functions used for all new functions/components; React components default-exported.
+- [ ] Server code sticks to CommonJS and lives inside the MVC structure (`controllers`, `routes`, `models`, `services/utils`).
+- [ ] Each React component owns a dedicated SCSS module with matching import path.
+- [ ] JWT auth flow, env vars, and CORS configuration remain secure; no secrets committed.
+- [ ] Tests added or updated for both server (Jest + Supertest) and client (Vitest) as applicable.
+- [ ] README and docs updated whenever APIs, env vars, scripts, or deployment steps change.

--- a/README.md
+++ b/README.md
@@ -1,71 +1,147 @@
 # CougarFinder
+CougarFinder is a MERN starter for location-aware matchmaking with an Express API, Socket.IO messaging, and a Vite-powered React landing experience.
 
-CougarFinder is a MERN starter tailored for matchmaking experiences. The project ships with a hardened Express API, a Vite-powered React client, and an end-to-end tooling setup that mirrors production expectations.
+## Tech Stack
+![MERN](https://img.shields.io/badge/Stack-MERN-green?logo=mongodb&logoColor=white)
+![JavaScript](https://img.shields.io/badge/Language-JavaScript-yellow?logo=javascript&logoColor=white)
+![SCSS Modules](https://img.shields.io/badge/Styles-SCSS%20Modules-ff69b4)
 
-## Tech stack
-- **Client:** React 18 (Vite), SCSS modules, React Query
-- **Server:** Node.js + Express, Mongoose, Socket.IO
-- **Testing:** Jest + Supertest (server), Vitest (client)
-
-## Prerequisites
-- Node.js 18+
-- npm 9+
-- MongoDB (local or managed). During development you may rely on an ephemeral in-memory instance by setting `USE_IN_MEMORY_DB=true`.
-
-## Environment configuration
-1. Install dependencies once per workspace:
+## Quick Start
+1. Clone the repo and install dependencies:
    ```bash
+   git clone https://github.com/kofiarhin/CougarFinder.git
+   cd CougarFinder
    npm install
    npm --prefix client install
    ```
-2. Copy the example environment files and adjust values as needed:
+2. Copy the sample environment files and adjust the values for your setup:
    ```bash
    cp server/.env.example server/.env
    cp client/.env.example client/.env
    ```
-3. For local development without MongoDB running, keep `USE_IN_MEMORY_DB=true` inside `server/.env`. When deploying, remove that flag and point `MONGO_URI` to your production cluster. Always provide a strong `JWT_SECRET` and explicitly list allowed origins in `CORS_ORIGIN` (comma separated for multiple domains).
+3. Run the local stack (Express API on port 5000, Vite dev server on port 5173):
+   ```bash
+   npm run dev
+   ```
 
-## Available scripts
-All scripts are exposed from the repository root and adhere to the conventions described in the project brief.
+## Environment Variables
+### Server (`server/.env`)
+| Key | Description | Default |
+| --- | --- | --- |
+| `PORT` | Port for the Express HTTP server. | `5000` |
+| `MONGO_URI` | MongoDB connection string. When omitted in development, the server falls back to an ephemeral in-memory instance. | `mongodb://127.0.0.1:27017/cougarfinder` |
+| `JWT_SECRET` | Secret used to sign auth tokens. Required in all environments. | `please-change-me` |
+| `JWT_EXPIRES_IN` | JWT expiry window. | `7d` |
+| `CORS_ORIGIN` | Allowed origins for CORS (comma-separated). Required in production; `*` is used automatically in development when left blank. | `http://localhost:5173` |
+| `USE_IN_MEMORY_DB` | Enables the MongoDB Memory Server fallback outside production. | `true` |
+| `UPLOAD_DIR` | Absolute or relative path for persisted uploads. | `server/uploads` |
 
-| Command | Description |
+### Client (`client/.env`)
+| Key | Description | Default |
+| --- | --- | --- |
+| `VITE_API_BASE` | Base URL for API requests from the client. | `http://localhost:5000` |
+
+## Scripts
+### Root scripts
+| Command | Purpose |
 | --- | --- |
-| `npm run dev` | Starts Express (port 5000) and Vite (port 5173) concurrently. |
-| `npm run server` | Runs the API with nodemon in development mode. |
-| `npm run client` | Starts the Vite dev server only. |
-| `npm start` | Boots the Express API for production. Requires a valid `MONGO_URI`. |
-| `npm run build` | Builds the React client and prepares server assets (ensures upload directories exist). |
-| `npm run build:client` | Builds the client (`client/dist`). |
-| `npm run build:server` | Prepares server uploads/asset directories for production deployment. |
-| `npm test` | Executes the Jest test suite under `server/tests`. |
-| `npm run test:client` | Executes Vitest in the client workspace. |
+| `npm start` | Run the Express server in production mode. |
+| `npm run dev` | Run the API and client concurrently (nodemon + Vite). |
+| `npm run server` | Start the API with nodemon and development env vars. |
+| `npm run client` | Launch the Vite development server only. |
+| `npm run build` | Build the React client and ensure server upload directories exist. |
+| `npm run build:client` | Build the client bundle under `client/dist`. |
+| `npm run build:server` | Prepare server-side upload directories for deployment. |
+| `npm test` / `npm run test:server` | Execute the Jest + Supertest API test suite. |
+| `npm run test:client` | Execute the Vitest suite inside `client/`. |
 
-### Client specific
-- `npm --prefix client run build` – builds the React app for static hosting.
-- `npm --prefix client run preview` – serves the built client locally.
+### Client workspace
+| Command | Purpose |
+| --- | --- |
+| `npm run dev` | Start the Vite dev server. |
+| `npm run build` | Build the static client bundle. |
+| `npm run preview` | Preview the built client locally. |
+| `npm run test` | Run Vitest against client tests. |
 
-### Server specific
-- `npm run server` (from the root) – reloads on changes with nodemon.
-- `npm run build:server` – prepares upload directories so the API can serve static assets immediately after deploy.
+## API Overview
+### Health
+- `GET /api/health` – Simple service heartbeat.
 
-## API health endpoint
-The API exposes a health check at `GET /api/health` that returns:
-```json
-{ "ok": true, "service": "CougarFinder" }
-```
-Use this route for uptime probes and deployment smoke tests.
+### Auth
+- `POST /api/auth/signup` – Register a user; stores hashed password and profile details.
+- `POST /api/auth/login` – Validate credentials and return a signed JWT.
+
+### Profile & Likes
+- `GET /api/users/me` – Fetch the authenticated user document.
+- `PATCH /api/users/me` – Update profile fields (bio, preferences, location, etc.).
+- `POST /api/users/like` – Upsert a like towards another user.
+
+### Images
+- `GET /api/users/me/images` – List the caller's stored images.
+- `POST /api/users/me/images` – Upload up to four images (`multipart/form-data`, field `images`).
+- `PATCH /api/users/me/images/:imageId/primary` – Mark a specific image as primary.
+- `DELETE /api/users/me/images/:imageId` – Remove an image and delete its file.
+
+### Matches
+- `GET /api/matches` – Browse active users filtered by age range, distance (km), and orientations (`orientations` query param expects comma-separated values).
+
+### Messages
+- `GET /api/messages` – Retrieve the latest message per conversation for the current user.
+- `GET /api/messages/thread?withUserId=` – Fetch chronological messages with a specific user (supports `limit`).
+
+### WebSocket Events (`/socket.io`)
+- **Handshake** – Requires a valid JWT via `Authorization: Bearer <token>` header or `auth.token` payload.
+- `message:send` – Persist and broadcast a new message (`{ toUserId, body }`).
+- `message:delivered` – Mark a message as delivered and notify the recipient.
+- `message:read` – Mark a message as read and notify the recipient.
+- `presence:user` (broadcast) – Online/offline presence updates.
+
+## Client Notes
+- Bootstrapped with Vite + React 18 and wrapped in a shared `QueryClientProvider` for React Query state management.
+- Content strings live in `client/src/content.json`; components pull copy through custom hooks instead of hard-coding.
+- Styles use SCSS modules (`*.styles.scss`) imported per component.
 
 ## Testing
-- Run **server tests** with `npm test`. The suite boots an isolated in-memory MongoDB instance via Jest + Supertest.
-- Run **client tests** with `npm run test:client`. The Vitest smoke test renders `<App />` inside a React Query provider to ensure the bundle loads.
+- API: `npm run test:server` spins up an in-memory MongoDB instance and exercises controllers, routes, and Socket.IO handlers with Jest + Supertest.
+- Client: `npm run test:client` runs Vitest against `client/src/__tests__` with JSDOM.
 
 ## Deployment
-- **Server (Render/Heroku):** The repository includes a `Procfile` (`web: npm start`). Configure environment variables (`PORT`, `MONGO_URI`, `JWT_SECRET`, `CORS_ORIGIN`, `UPLOAD_DIR`) in your platform dashboard. Render can run the root project with build command `npm install && npm --prefix client install && npm --prefix server install && npm run build` and start command `npm start`.
-- **Client (Vercel/Netlify):** Deploy `client/` as a static site. Build command `npm install && npm run build` executed from `client/`. Set `VITE_API_BASE` to the deployed API URL.
-- Ensure `CORS_ORIGIN` contains the production client domain(s) before promoting the API.
+### Server (Render or Heroku)
+1. Configure build command `npm install && npm --prefix client install && npm run build`.
+2. Set start command `npm start` (Procfile already declares `web: npm start`).
+3. Provide required env vars (`PORT`, `MONGO_URI`, `JWT_SECRET`, `CORS_ORIGIN`, `UPLOAD_DIR`, optional `JWT_EXPIRES_IN`, `USE_IN_MEMORY_DB` false in production).
 
-## Additional notes
-- The Express server enforces strict JSON/urlencoded parsing limits, centralised error handling, a `/api/health` heartbeat, and in-memory rate limiting on authentication routes.
-- Environment variables are applied consistently across platforms via the `scripts/run-with-env.js` helper so commands stay cross-platform without additional dependencies.
-- Socket.IO inherits the same CORS configuration as HTTP routes to respect environment restrictions.
-- Static uploads live under `/uploads`; change `UPLOAD_DIR` via environment variables when using object storage providers.
+### Client (Vercel)
+1. Deploy the `client/` directory with build command `npm install && npm run build` and output `dist`.
+2. Set `VITE_API_BASE` to the deployed server URL.
+3. Ensure the API's `CORS_ORIGIN` allows the Vercel domain.
+
+## Folder Structure
+```
+.
+├── client/
+│   ├── src/
+│   │   ├── App.jsx
+│   │   ├── hooks/
+│   │   ├── constants/
+│   │   ├── styles/
+│   │   └── __tests__/
+│   └── package.json
+├── server/
+│   ├── controllers/
+│   ├── routes/
+│   ├── models/
+│   ├── middleware/
+│   ├── utils/
+│   ├── tests/
+│   └── socket.js
+├── scripts/run-with-env.js
+├── Procfile
+├── package.json
+└── README.md
+```
+
+## Roadmap
+- Expand the client beyond the landing page with authenticated flows for browsing, messaging, and profile management.
+- Expose moderation/report management endpoints built around `Report` models.
+- Add automated deployment workflows (GitHub Actions) to run tests and trigger platform deploys.


### PR DESCRIPTION
## Summary
- Rewrite README with current setup, environment variables, scripts, API surface, sockets, testing, and deployment guidance.
- Replace AGENTS instructions with an operational playbook covering conventions, helper agents, templates, and PR checklist.

## Diff Summary
- [x] README – Cross-referenced `package.json`, `client/package.json`, `server/routes/*.js`, `server/controllers/*.js`, `server/socket.js`, and client hooks/constants.
- [x] AGENTS – Grounded in the present server MVC layout, client SCSS module usage, and testing setup under `server/tests` and `client/src/__tests__`.

## How this was derived
- Scripts & tooling: `package.json`, `client/package.json`
- API & models: `server/index.js`, `server/routes/*.js`, `server/controllers/*.js`, `server/models/*.js`, `server/utils/**/*.js`
- Realtime & auth: `server/socket.js`, `server/middleware/authMiddleware.js`
- Client architecture: `client/src/App.jsx`, `client/src/hooks/useHealthCheck.js`, `client/src/hooks/useContent.js`, `client/src/constants/baseURL.js`


------
https://chatgpt.com/codex/tasks/task_e_68d879ff62ac8330bf59aade4649a0d4